### PR TITLE
[DO NOT MERGE] Add mongodb as storage for questions

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+
+COPY . /app
+WORKDIR /app
+
+RUN apt update
+RUN apt install -y python3.7 python3-pip
+RUN pip3 install -r requirements.txt
+
+EXPOSE 8000
+ENTRYPOINT ["./entrypoint.sh"]

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  zno_api:
+    image: zno_api
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - mongo
+    ports:
+      - "8000:8000"
+    restart: always
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+    restart: always

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec gunicorn app -b 0.0.0.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,5 @@
-falcon>=2.0.0
-gunicorn>=19.9.0
+falcon==2.0.0
+gunicorn==19.9.0
 requests==2.22.0
 sentry-sdk==0.12.3
+pymongo==3.9.0

--- a/api/zno_api_resources.py
+++ b/api/zno_api_resources.py
@@ -23,7 +23,7 @@ class QuestionsResource():
             resp.status = falcon.HTTP_404
 
         else:
-            resp.media = {'id': question['id'],
+            resp.media = {'id': question['_id'],
                           'content': question['content'],
                           'choices': [{'id': choice['id'], 'content': choice['content']}
                                       for choice in question['choices']]}


### PR DESCRIPTION
We need to fix scrapper now, so it store questions to mongodb. Maybe, we will need to create general docker-compose.yml for all our applications. For the moment, we can upload questions from file "questions.json" via the following script:

```
import json
import pymongo

myclient = pymongo.MongoClient("mongodb://localhost:27017/")

mydb = myclient["zno_questions"]
mycollection = mydb["ua_lang_and_literature"]


def save_to_mongo():
    with open('questions.json') as f:
        questions = json.load(f)
        for q in questions:
            q['_id'] = q.pop('id')

    mycollection.insert_many(questions)

save_to_mongo()
```

Reviewers:
- [ ] @lynxrv21 
- [ ] @vasyabigi 